### PR TITLE
Botón de tareas y desbordamiento

### DIFF
--- a/src/main/java/edu/eci/labinfo/labtodo/model/Status.java
+++ b/src/main/java/edu/eci/labinfo/labtodo/model/Status.java
@@ -6,10 +6,10 @@ package edu.eci.labinfo.labtodo.model;
  */
 public enum Status {
 
-    INPROCESS("En Proceso"),
-    FINISH("Finalizada"),
     PENDING("Por Hacer"),
-    REVIEW("Revisión");
+    INPROCESS("En Proceso"),
+    REVIEW("En Revisión"),
+    FINISH("Finalizada");
 
     private String value;
 
@@ -38,5 +38,9 @@ public enum Status {
             }
         }
         return response;
+    }
+
+    public Status next() {
+        return Status.values()[ordinal() + 1];
     }
 }

--- a/src/main/webapp/css/settings.css
+++ b/src/main/webapp/css/settings.css
@@ -1,6 +1,7 @@
 .user-mod {
     width: 100%;
     background: linear-gradient(to bottom right, #7dcc7f, #3dcc63, #2b9440);
+    overflow: auto;
 }
 
 .users-list {

--- a/src/main/webapp/css/taskdashboard.css
+++ b/src/main/webapp/css/taskdashboard.css
@@ -91,6 +91,7 @@ header {
 .task-crud {
     width: 100%;
     background: linear-gradient(to bottom right, #7dcc7f, #3dcc63, #2b9440);
+    overflow: auto;
 }
 
 #form {

--- a/src/main/webapp/public/admindashboard.xhtml
+++ b/src/main/webapp/public/admindashboard.xhtml
@@ -171,9 +171,9 @@
         <p:outputPanel id="update-status-content">
           <p:selectOneMenu id="status" value="#{adminBean.newState}" label="Text 2">
             <f:selectItem itemLabel="Seleccionar estado" itemValue="" noSelectionOption="true"/>
-            <f:selectItem itemLabel="En Proceso" itemValue="En Proceso"/>
             <f:selectItem itemLabel="Por Hacer" itemValue="Por Hacer"/>
-            <f:selectItem itemLabel="Revisión" itemValue="Revisión"/>
+            <f:selectItem itemLabel="En Proceso" itemValue="En Proceso"/>
+            <f:selectItem itemLabel="En Revisión" itemValue="En Revisión"/>
             <f:selectItem itemLabel="Finalizada" itemValue="Finalizada"/>
           </p:selectOneMenu>
         </p:outputPanel>

--- a/src/main/webapp/public/dashboard.xhtml
+++ b/src/main/webapp/public/dashboard.xhtml
@@ -90,11 +90,12 @@
                     <span class="task-type task-type-#{task.typeTask}" >#{task.typeTask}</span>
                     <h4 class="mb-1">#{task.title}</h4>
                     <p>#{task.description}</p>
-                    <p class="task-status">#{task.status}</p>
+                    <p class="task-status" >#{task.status} #{taskBean.getRenderedToTaskButton(loginBean.userName, task)}</p>
                   </article>
                 </p:commandLink>
-                <p:commandButton value="Completar" icon="pi pi-send" styleClass="button ui-button-success  rounded-button"
-                  oncomplete="PF('completeTaskDialog').show()">
+                <p:commandButton value="#{taskBean.getMessageToTaskButton(task)}" icon="pi pi-send" 
+                  rendered="#{taskBean.getRenderedToTaskButton(loginBean.userName, task)}" styleClass="button ui-button-success  rounded-button" 
+                  oncomplete="PF('completeTaskDialog').show()" update="@this :dialogs:completeTaskDialog">
                   <f:setPropertyActionListener target="#{taskBean.currentTask}" value="#{task}" />
                 </p:commandButton>
               </p:carousel>
@@ -118,11 +119,12 @@
                     <span class="task-type task-type-#{task.typeTask}" >#{task.typeTask}</span>
                     <h4 class="mb-1">#{task.title}</h4>
                     <p>#{task.description}</p>
-                    <p class="task-status">#{task.status}</p>
+                    <p class="task-status" >#{task.status}</p>
                   </article>
                 </p:commandLink>
-                <p:commandButton value="Completar" icon="pi pi-send" styleClass="button ui-button-success  rounded-button" 
-                 oncomplete="PF('completeTaskDialog').show()">
+                <p:commandButton value="#{taskBean.getMessageToTaskButton(task)}" icon="pi pi-send" 
+                  rendered="#{taskBean.getRenderedToTaskButton(loginBean.userName, task)}" styleClass="button ui-button-success  rounded-button" 
+                  oncomplete="PF('completeTaskDialog').show()" update="@this :dialogs:completeTaskDialog">
                   <f:setPropertyActionListener target="#{taskBean.currentTask}" value="#{task}" />
                 </p:commandButton>
               </p:carousel>
@@ -181,8 +183,8 @@
         <p:messages for="somekey" />
       </p:dialog>
        <!-- Dialogo para completar tarea -->
-      <p:confirmDialog widgetVar="completeTaskDialog" showEffect="fade" width="300"
-       message="Completar tarea?" header="Confirmar" severity="warn">
+      <p:confirmDialog id="completeTaskDialog" widgetVar="completeTaskDialog" showEffect="fade" width="300"
+        message="#{taskBean.getMessageToTaskButton(taskBean.currentTask)} la tarea?" header="Confirmar" severity="warn">
         <p:commandButton value="Si" icon="pi pi-check" actionListener="#{taskBean.completedMessage}"
           process="@this" oncomplete="PF('completeTaskDialog').hide()" />
         <p:commandButton value="No" type="button" styleClass="ui-button-secondary" icon="pi pi-times"

--- a/src/main/webapp/public/task.xhtml
+++ b/src/main/webapp/public/task.xhtml
@@ -55,7 +55,7 @@
           </li>
         </ul>
       </nav>
-      <div class="details-task">
+      <div class="task-crud">
         <h:form id="form">
           <p:growl id="growl" showDetail="true" />
           <p:toolbar styleClass="mi-toolbar">
@@ -66,8 +66,9 @@
               <p:commandButton value="Comentar" icon="pi pi-comments" styleClass="button ui-button-help  rounded-button mr-2"
                 actionListener="#{taskBean.openComment}" update=":dialogs:manage-comment-content" oncomplete="PF('manageCommentDialog').show()" >
               </p:commandButton>
-              <p:commandButton value="Completar" icon="pi pi-send" styleClass="button ui-button-success  rounded-button"
-                oncomplete="PF('completeTaskDialog').show()">
+              <p:commandButton id="task-button" value="#{taskBean.getMessageToTaskButton(taskBean.currentTask)}" icon="pi pi-send" 
+                rendered="#{taskBean.getRenderedToTaskButton(loginBean.userName, taskBean.currentTask)}"
+                styleClass="button ui-button-success  rounded-button" oncomplete="PF('completeTaskDialog').show()" update="@this">
               </p:commandButton>
             </p:toolbarGroup>
           </p:toolbar>
@@ -81,8 +82,9 @@
               <p:outputLabel value="Asignado a: #{taskBean.currentTask.getAllUsers()}" />
             </p:panelGrid>
             <p:divider />
-            <p:dataTable id="comments-list" var="comment"  value="#{taskBean.getCurrentTaskComments()}" reflow="true" rowKey="#{comment.commentId}" paginator="true" rows="10" paginatorPosition="bottom"
-            paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}">
+            <p:dataTable id="comments-list" var="comment"  value="#{taskBean.getCurrentTaskComments()}" reflow="true" rowKey="#{comment.commentId}" paginator="true"
+              rows="5" paginatorPosition="bottom"
+              paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}">
               <f:facet name="header">
                 <div class="comments-list-header">
                   <span style="font-weight: bold">Comentarios</span>
@@ -139,11 +141,11 @@
               class="ui-button-secondary" type="button" />
         </f:facet>
       </p:dialog>
-       <!-- Dialogo para completar tarea -->
+       <!-- Dialogo para iniciar/revisar/completar tarea -->
       <p:confirmDialog widgetVar="completeTaskDialog" showEffect="fade" width="300"
-       message="Completar tarea?" header="Confirmar" severity="warn">
+       message="#{taskBean.getMessageToTaskButton(taskBean.currentTask)} la tarea?" header="Confirmar" severity="warn">
         <p:commandButton value="Si" icon="pi pi-check" actionListener="#{taskBean.completedMessage}"
-          update=":form:details-panel" process="@this" oncomplete="PF('completeTaskDialog').hide()" />
+          update="form" process="@this" oncomplete="PF('completeTaskDialog').hide()" />
         <p:commandButton value="No" type="button" styleClass="ui-button-secondary" icon="pi pi-times"
           onclick="PF('completeTaskDialog').hide()" />
       </p:confirmDialog>


### PR DESCRIPTION
**Botón de tarea:** 
Ahora los usuarios pueden iniciar tareas, ponerlas en revisión y finalizarlas
![image](https://github.com/Laboratorio-de-Informatica/LabToDo/assets/99996670/98e233c0-3b85-4542-a264-90e2bdccb0f4)

Una vez iniciada una tarea se pondrá en proceso, y cuando se considere el usuario la llevará a revisión de nuevo en el botón
![image](https://github.com/Laboratorio-de-Informatica/LabToDo/assets/99996670/2cd98052-6a7a-4622-8132-189d4ed92f6b)

Una vez en revisión si el usuario es un monitor no podrá finalizar la tarea
![image](https://github.com/Laboratorio-de-Informatica/LabToDo/assets/99996670/ca4f8cbf-c78c-4268-b2b8-7df258e5d9c1)

Adiferencia de un usuario administrador que si tiene acceso a esta funcionalidad
![image](https://github.com/Laboratorio-de-Informatica/LabToDo/assets/99996670/d33e1335-602c-4153-a2e7-579de66fbbc9)

Una vez finalizada una tarea el botón desaparecerá indicando el fin del ciclo de vida de una tarea
![image](https://github.com/Laboratorio-de-Informatica/LabToDo/assets/99996670/a9b9b3ee-32f0-4869-8476-0eac5e60ddd1)


**Correcciones:** 
Se realizan correcciones de desbordamiento en los carruseles y tablas de la aplicación
